### PR TITLE
Indexer/Browser: better responsabilities and clean interface

### DIFF
--- a/app/Slider.hs
+++ b/app/Slider.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import           Slidecoding             (Description(..), Module(..), index, loadExposedModules, load, ValidationMessage, Presentation(..), Metadata(..))
+import           Slidecoding             (Description(..), Module(..), browse, loadExposedModules, load, ValidationMessage, Presentation(..), Metadata(..))
 import           Slidecoding.SlidesWriter
 
 import           Control.Monad           ((>=>), when)
@@ -72,7 +72,7 @@ checkPresentation = load >=> printResult
 loadModules :: FilePath -> IO [Description]
 loadModules path = do
   modules <- loadExposedModules path
-  maybe (return []) (mapM index) modules
+  maybe (return []) (mapM browse) modules
 
 describeModules :: [Description] -> IO ()
 describeModules []      = putStrLn "  No modules"

--- a/src/Slidecoding.hs
+++ b/src/Slidecoding.hs
@@ -1,9 +1,7 @@
 module Slidecoding
     (
     -- Browser
-      browseSignatures
-    , browseSymbols
-    , source
+      browse
 
     -- CabalHelper
     , loadExposedModules
@@ -13,10 +11,6 @@ module Slidecoding
     , ioStream
 
     -- Indexer
-    , Description(..)
-    , Source(..)
-    , Item(..)
-    , index
     , indexIO
 
     -- Presentation
@@ -33,10 +27,13 @@ module Slidecoding
 
     -- Types
     , Context(..)
+    , Description(..)
+    , Item(..)
     , Module(..)
     , ModuleName
     , Name
     , Port
+    , Source(..)
     , Stream(..)
     , Symbol(..)
     , singleModuleContext

--- a/src/Slidecoding/Indexer.hs
+++ b/src/Slidecoding/Indexer.hs
@@ -1,50 +1,29 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Slidecoding.Indexer
-    ( Description(..)
-    , Source(..)
-    , Item(..)
-    , index
-    , indexIO
+    ( indexIO
     ) where
 
 import Slidecoding.Browser
 import Slidecoding.Types
 
-import Codec.Binary.Base64.String as B64 (encode)
-
+import Codec.Binary.Base64.String as B64 (decode)
 import Data.Aeson                 hiding (encode)
 import Data.Aeson                 as A   (encode)
 import Data.ByteString.Lazy.Char8 as B   (hPutStrLn)
-import Data.Char                         (isSpace)
-import Data.List                         (intercalate)
 import Data.Text                  as L   (pack)
 
 import System.FilePath                   ((</>), (<.>))
 import System.IO                         (IOMode(..), withFile)
 
-data Description = Description Module [Item]
-data Item = Item Symbol Signature Source
-newtype Source = Source String
-
-index :: Module -> IO Description
-index m = do
-  ss   <- browseSymbols m
-  sigs <- browseSignatures m
-  loadDescription m ss sigs
-
 indexIO :: Module -> FilePath -> IO ()
 indexIO m dir = do
-  description <- index m
+  description <- browse m
   writeIndexJson dir description
-  mapM_ (writeSource m dir) (symbols description)
-
-symbols :: Description -> [Symbol]
-symbols (Description _ items) = map symbol items
-  where symbol (Item s _ _) = s
+  writeSources dir description
 
 writeIndexJson :: FilePath -> Description -> IO ()
-writeIndexJson dir description = writeJSON file description
+writeIndexJson dir description = writeJSON file (D' description)
   where file = dir </> m' <.> "json"
         Description (Module _ m') _ = description
 
@@ -52,20 +31,10 @@ writeJSON :: ToJSON a => FilePath -> a -> IO ()
 writeJSON file o = withFile file WriteMode handler
   where handler f = B.hPutStrLn f (A.encode o)
 
-base64 :: String -> String
-base64 = filter (not . isSpace) . B64.encode
+newtype Description' = D' Description
 
-loadDescription :: Module -> [Symbol] -> [Signature] -> IO Description
-loadDescription m ss sigs = Description m <$> loadItems m ss sigs
-
-loadItems :: Module -> [Symbol] -> [Signature] -> IO [Item]
-loadItems m ss sigs = mapM (loadItem m) $ zip ss sigs
-
-loadItem :: Module -> (Symbol, Signature) -> IO Item
-loadItem m (s, sig) = Item s sig . Source . base64 . intercalate "\n" <$> source m s
-
-instance ToJSON Description where
-  toJSON (Description (Module _ m) items) = object [ L.pack m .= object (map toPair items) ]
+instance ToJSON Description' where
+  toJSON (D' (Description (Module _ m) items)) = object [ L.pack m .= object (map toPair items) ]
     where toPair (Item (Symbol s) (Signature sig) (Source src64)) =
               L.pack s .=
                 object [ "qname"        .= qname s
@@ -76,9 +45,11 @@ instance ToJSON Description where
           qname s = m ++ "." ++ s
           sourceFile s = m ++ "_" ++ s <.> "hs"
 
-writeSource :: Module -> FilePath -> Symbol -> IO ()
-writeSource m@(Module _ m') dir s@(Symbol s') = do
-  content <- unlines <$> source m s
-  writeFile file content
+writeSources :: FilePath -> Description -> IO ()
+writeSources dir (Description m items) = mapM_ (writeItem dir m) items
+
+writeItem :: FilePath -> Module -> Item -> IO ()
+writeItem dir (Module _ m) (Item (Symbol s) _ (Source src)) =
+  writeFile file (B64.decode src)
     where file = dir </> qname <.> "hs"
-          qname = m' ++ "_" ++ s'
+          qname = m ++ "_" ++ s

--- a/src/Slidecoding/SlidesWriter.hs
+++ b/src/Slidecoding/SlidesWriter.hs
@@ -3,7 +3,6 @@ module Slidecoding.SlidesWriter
     ) where
 
 import Slidecoding.Types
-import Slidecoding.Indexer               (Description(..), Item(..), Source(..))
 
 import Codec.Binary.Base64.String as B64 (decode)
 

--- a/src/Slidecoding/Types.hs
+++ b/src/Slidecoding/Types.hs
@@ -2,11 +2,14 @@
 
 module Slidecoding.Types
     ( Context(..)
+    , Description(..)
+    , Item(..)
     , Module(..)
     , ModuleName
     , Name
     , Port
     , Signature(..)
+    , Source(..)
     , Stream(..)
     , Symbol(..)
     , singleModuleContext
@@ -21,6 +24,10 @@ type ModuleName = String
 data Module       = Module FilePath ModuleName
 newtype Symbol    = Symbol String
 newtype Signature = Signature String
+
+data Description = Description Module [Item]
+data Item = Item Symbol Signature Source
+newtype Source = Source String
 
 singleModuleContext :: ModuleName -> Context
 singleModuleContext moduleName = Context moduleName [path] [moduleName] []


### PR DESCRIPTION
Clean interface:
- `slider` only rely on `Browser`, no more on `Indexer`
- Types moved to the `Types` module
- browsing exported by `Browser` module
- indexer only there for actual indexation (producing index files from a module) ; not used now

Make it more efficient:
- Load source files only once (n times before, where n is the number of symbols)
- Index API only once (twice before) and deduce names from the signatures
