### PR TITLE
Define contexts in presentation.yaml

### DIFF
--- a/demo/demo.cabal
+++ b/demo/demo.cabal
@@ -16,6 +16,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Example1
                      , Example2
+  other-modules:       Utils
   build-depends:       base >= 4.7 && < 5
   default-language:    Haskell2010
 

--- a/demo/presentation.yaml
+++ b/demo/presentation.yaml
@@ -7,3 +7,9 @@ design:
   theme:
     base: neon
     custom: "assets/custom.css"
+contexts:
+  chapter1:
+    module: Example1
+  chapter2:
+    module: Example2
+    others: [ Utils ]

--- a/demo/slides/chapter2.md
+++ b/demo/slides/chapter2.md
@@ -1,6 +1,6 @@
 ---
 title: 'Chapter 2'
-context: 'Example2'
+context: 'chapter2'
 ...
 
 # Try it {.repl}

--- a/demo/src/Utils.hs
+++ b/demo/src/Utils.hs
@@ -1,0 +1,4 @@
+module Utils where
+
+inspect :: Show a => IO a -> IO ()
+inspect = (=<<) print

--- a/slidecoding.cabal
+++ b/slidecoding.cabal
@@ -64,6 +64,7 @@ library
                      , pandoc-types
                      , blaze-html
                      , containers
+                     , unordered-containers
   default-language:    Haskell2010
 
 executable slider

--- a/src/Slidecoding/WebSockets.hs
+++ b/src/Slidecoding/WebSockets.hs
@@ -3,13 +3,13 @@ module Slidecoding.WebSockets
     ) where
 
 import Slidecoding.GHCI  (run)
-import Slidecoding.Types (Port, Context, Stream(..))
+import Slidecoding.Types (Port, Presentation, Stream(..))
 
 import qualified Data.ByteString.Lazy.Char8 as C
 import qualified Network.WebSockets         as WS
 
-start :: Port -> Context -> IO ()
-start port ctx = WS.runServer "0.0.0.0" port $ application ctx
+start :: Port -> Presentation -> IO ()
+start port p = WS.runServer "0.0.0.0" port $ application p
 
 wsStream :: WS.Connection -> Stream IO
 wsStream conn = Stream nothing input output
@@ -17,8 +17,8 @@ wsStream conn = Stream nothing input output
         input   = C.unpack <$> WS.receiveData conn
         output  = WS.sendTextData conn . C.pack
 
-application :: Context -> WS.ServerApp
-application ctx pending = do
+application :: Presentation -> WS.ServerApp
+application p pending = do
   conn <- WS.acceptRequest pending
   WS.forkPingThread conn 30
-  run (wsStream conn) ctx
+  run (wsStream conn) p


### PR DESCRIPTION
Define module + additional modules as contexts.

``` yaml
contexts:
  example1:
    module: Example1
  example2:
    module: Example2
    others: [ Utils ]
```

The context name will be used by the REPL in every chapter by specifying the name in chapter's metadata :

``` yaml
context : "example1"
```